### PR TITLE
Add `preventAssignment: true` option

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,7 @@ export default [
       resolve(),
       commonjs(),
       replace({
+        preventAssignment: true,
         "process.env.NODE_ENV": JSON.stringify("production"),
       }),
       terser({


### PR DESCRIPTION
To get rid of the yellow message when running `make`, and of possible accidental replacements.